### PR TITLE
Add custom wheel event handler and other props

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@
      - `deregisterCharacterJoiner` (not implemented)
      - `registerMarker` (not implemented)
      - `registerDecoration` (not implemented)
-7. Development. Use `vite` for e2e test, much faster than `webpack`.
+7. Development and test. Use `vite` for e2e test, much faster than `webpack`.
+   - #TODO: test the add-ons.

--- a/README.md
+++ b/README.md
@@ -5,16 +5,22 @@
    The `xterm-addon-fit` is not working properly. It's not resizing the terminal when the window is resized.
 3. Code style.
    - Naming (`XTerm` instead of `Xterm`, etc.)
-   - expose more methods like `.write()` directly, with docstrings! so we no longer need to say `.current.terminal.write()` any more, as they become `use .current.write()`
+   - expose more methods like `.write()`, `blur()`, etc. from the XTerm class with docstrings. So we no longer need to say `.current.terminal.write()` any more, as they become `.current.write()`
      This (exposing many methods) generally has minimal impact on performance but can affect memory usage slightly if many instances are created.
    - Use `@typescript-eslint` instead of `tslint`.
 4. Functionality.
-
    - Hook new event listeners from XTerm like `onBell()` and `onWriteParsed()`.
    - Expose terminal methods like `blur()`, `focus()`, etc.
-   - New custom event handler for `attachCustomWheelEventHandler()`.
+   - New props for event handlers like `attachCustomWheelEventHandler()`, `registerLinkProvider()`, etc.
    - New link provider for `registerLinkProvider()`.
-
 5. Performance. Remove dynamic type checking. It's not necessary and the performance is not good.
-6. Documentation. Slightly changes the documentation to align with that from `@xterm/xterm`, with new types like `IEventListener`.
+6. Documentation.
+   - Slightly changes the documentation to align with that from `@xterm/xterm`, with new types like `IEventListener`.
+   - Add comments for these methods:
+     - `attachCustomWheelEventHandler` (new)
+     - `registerLinkProvider` (new)
+     - `registerCharacterJoiner` (new)
+     - `deregisterCharacterJoiner` (not implemented)
+     - `registerMarker` (not implemented)
+     - `registerDecoration` (not implemented)
 7. Development. Use `vite` for e2e test, much faster than `webpack`.

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -16,6 +16,7 @@
       import { Terminal } from "@xterm/xterm";
       import "@xterm/xterm/css/xterm.css";
 
+      const TEST_DECORATION = false;
       const terminalElement = document.getElementById("terminal");
       if (terminalElement === null) {
         throw new Error("Terminal element not found");
@@ -27,32 +28,34 @@
       term.open(terminalElement);
       term.writeln("Hello from \x1B[1;3;31mxterm.js\x1B[0m ");
       term.write("$ ");
-      const marker = term.registerMarker(0);
-      const decoration = term.registerDecoration({
-        marker: marker,
-        anchor: "right",
-        x: 3,
-        width: 5,
-        height: 2,
-        backgroundColor: "#ff0000", // red
-        foregroundColor: "#0000ff", // blue
-        layer: "top",
-        overviewRulerOptions: {
-          color: "#ff0000",
-          position: "center",
-        },
-      });
-      if (decoration === undefined) {
-        throw new Error("Decoration not found");
+      if (TEST_DECORATION) {
+        const marker = term.registerMarker(0);
+        const decoration = term.registerDecoration({
+          marker: marker,
+          anchor: "right",
+          x: 3,
+          width: 5,
+          height: 2,
+          backgroundColor: "#ff0000", // red
+          foregroundColor: "#0000ff", // blue
+          layer: "top",
+          overviewRulerOptions: {
+            color: "#ff0000",
+            position: "center",
+          },
+        });
+        if (decoration === undefined) {
+          throw new Error("Decoration not found");
+        }
+        console.log("decoration : ", decoration); // DEV_LOG_TO_REMOVE
+        decoration.onRender((element) => {
+          element.classList.add("link-hint-decoration");
+          element.innerText = "Try clicking italic text";
+          // must be inlined to override inlined width/height coming from xterm
+          element.style.height = "";
+          element.style.width = "";
+        });
       }
-      console.log("decoration : ", decoration); // DEV_LOG_TO_REMOVE
-      decoration.onRender((element) => {
-        element.classList.add("link-hint-decoration");
-        element.innerText = "Try clicking italic text";
-        // must be inlined to override inlined width/height coming from xterm
-        element.style.height = "";
-        element.style.width = "";
-      });
     </script>
     <!-- To test if vite can load local resource -->
     <img src="/Lenna.webp" alt="Lenna" />

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -17,18 +17,44 @@
       import "@xterm/xterm/css/xterm.css";
 
       const terminalElement = document.getElementById("terminal");
-      if (terminalElement) {
-        const term = new Terminal();
-        term.onData((data) => {
-          term.write(data);
-        });
-        term.open(terminalElement);
-        term.writeln("Hello from \x1B[1;3;31mxterm.js\x1B[0m ");
-        term.write("$ ");
-      } else {
-        console.error("Terminal element not found");
+      if (terminalElement === null) {
+        throw new Error("Terminal element not found");
       }
+      const term = new Terminal({ cursorBlink: true, allowProposedApi: true });
+      term.onData((data) => {
+        term.write(data);
+      });
+      term.open(terminalElement);
+      term.writeln("Hello from \x1B[1;3;31mxterm.js\x1B[0m ");
+      term.write("$ ");
+      const marker = term.registerMarker(0);
+      const decoration = term.registerDecoration({
+        marker: marker,
+        anchor: "right",
+        x: 3,
+        width: 5,
+        height: 2,
+        backgroundColor: "#ff0000", // red
+        foregroundColor: "#0000ff", // blue
+        layer: "top",
+        overviewRulerOptions: {
+          color: "#ff0000",
+          position: "center",
+        },
+      });
+      if (decoration === undefined) {
+        throw new Error("Decoration not found");
+      }
+      console.log("decoration : ", decoration); // DEV_LOG_TO_REMOVE
+      decoration.onRender((element) => {
+        element.classList.add("link-hint-decoration");
+        element.innerText = "Try clicking italic text";
+        // must be inlined to override inlined width/height coming from xterm
+        element.style.height = "";
+        element.style.width = "";
+      });
     </script>
+    <!-- To test if vite can load local resource -->
     <img src="/Lenna.webp" alt="Lenna" />
   </body>
 </html>

--- a/e2e/main.jsx
+++ b/e2e/main.jsx
@@ -7,7 +7,7 @@ const App = () => {
   const xTermRef = useRef(null);
   useEffect(() => {
     xTermRef.current?.terminal.writeln(
-      "Hello from \x1B[1;3;31mxterm.js\x1B[0m $ ",
+      "Hello from \x1B[1;3;31mxterm-react\x1B[0m",
     );
     xTermRef.current?.terminal.write("$ ");
   }, []);


### PR DESCRIPTION
Adds support for custom wheel event handling and other terminal functionalities in the `XTerm` component.

- Implements the `customWheelEventHandler` prop in the `XTermProps` interface with a docstring, allowing users to attach a custom wheel event handler to the terminal.
- Adds props for `linkProvider`, `characterJoiner`, `deregisterCharacterJoiner`, `registerMarker`, and `registerDecoration` in the `XTermProps` interface, each with appropriate docstrings. These props enable users to register custom handlers and providers for various terminal functionalities.
- Processes the `customWheelEventHandler` in the `XTerm` component constructor, attaching it to the terminal instance if provided.
- Includes placeholders and docstrings for handling `linkProvider`, `characterJoiner`, `deregisterCharacterJoiner`, `registerMarker`, and `registerDecoration` props, indicating an intention to implement these functionalities in the future.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PabloLION/xterm-react?shareId=8caa7017-1bca-4405-a780-dc3cccf762f0).