### PR TITLE
Configure dependabot for xterm.js, TypeScript, and React

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "@xterm/xterm"
+        update-types: ["patch", "major"]
+      - dependency-name: "typescript"
+        update-types: ["patch", "major"]
+      - dependency-name: "react"
+        update-types: ["patch", "minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    assignees:
+      - "PabloLION"
     ignore:
       - dependency-name: "@xterm/xterm"
-        update-types: ["patch", "major"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
       - dependency-name: "typescript"
-        update-types: ["patch", "major"]
+        update-types:
+          - "version-update:semver-patch"
       - dependency-name: "react"
-        update-types: ["patch", "minor"]
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
Adds a Dependabot configuration to the repository.

- **Configuration Added**: A `.github/dependabot.yml` file is introduced to enable Dependabot updates for the project.
- **Package Ecosystem**: Specifies the package ecosystem as "npm" and sets the directory to the root ("/").
- **Schedule**: Configures Dependabot to run on a weekly schedule.
- **Versioning Strategy**: Implements a versioning strategy where Dependabot ignores patch and major updates for `@xterm/xterm` and `typescript`, and patch and minor updates for `react`. This aligns with the task to monitor `@xterm/xterm` and `typescript` for minor version changes, and `react` for major version changes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PabloLION/xterm-react?shareId=d65a0d71-7311-4ef6-a46d-9ebb3b182fae).