### PR TITLE
chore(devhooks): run auto-fix lint and format in pre-push

### DIFF
--- a/dev/git-hooks/pre-push
+++ b/dev/git-hooks/pre-push
@@ -2,7 +2,7 @@
 # Add husky if needed
 # . "$(dirname "$0")/_/husky.sh"
 
-pnpm run lint:fix
+pnpm run lint
 pnpm run format
 
 # Check for uncommitted changes after running the format script


### PR DESCRIPTION
Update dev pre-push hook to run the auto-fix lint (`pnpm lint`) and formatting (`pnpm format`) instead of a missing `lint:fix` script.\n\nThis ensures local pushes repair fixable issues and fail if formatting introduces diffs (existing diff check remains).